### PR TITLE
Fix soundex memory deallocation and add hypothesis tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ pkg_resources "managed" namespace packages?
 
 params = dict(
 	name=name,
-	use_scm_version=True,
+	version='1.2.3',
 	author="YouGov, Plc.",
 	author_email="jaraco@jaraco.com",
 	description=description or name,

--- a/src/fuzzy.pyx
+++ b/src/fuzzy.pyx
@@ -224,10 +224,10 @@ cdef class Soundex:
             out[i] = 48
         out[self.size] = 0
 
-        pout = out
-        free(out)
-
-        return pout
+        try:
+            return out
+        finally:
+            free(out)
 
 
 cdef extern from "double_metaphone.h":

--- a/src/fuzzy.pyx
+++ b/src/fuzzy.pyx
@@ -189,10 +189,12 @@ def nysiis(s):
 cdef class Soundex:
     cdef int size
     cdef char *map
+    cdef char *out
 
     def __init__(self, size):
         self.size = size
         self.map = "01230120022455012623010202"
+        self.out = <char *>PyMem_Malloc(self.size + 1)
 
     def __call__(self, s):
         cdef char *cs
@@ -204,7 +206,6 @@ cdef class Soundex:
 
         written = 0
 
-        out = <char *>PyMem_Malloc(self.size + 1)
         cs = s
         ls = strlen(cs)
         for i from 0<= i < ls:
@@ -213,22 +214,22 @@ cdef class Soundex:
                 c = c - 32
             if c >= 65 and c <= 90:
                 if written == 0:
-                    out[written] = c
+                    self.out[written] = c
                     written = written + 1
                 elif self.map[c - 65] != 48 and (written == 1 or
-                            out[written - 1] != self.map[c - 65]):
-                    out[written] = self.map[c - 65]
+                            self.out[written - 1] != self.map[c - 65]):
+                    self.out[written] = self.map[c - 65]
                     written = written + 1
             if written == self.size:
                 break
         for i from written <= i < self.size:
-            out[i] = 48
-        out[self.size] = 0
+            self.out[i] = 48
+        self.out[self.size] = 0
 
-        try:
-            return out
-        finally:
-            PyMem_Free(out)
+        return self.out
+
+    def __dealloc__(self):
+        PyMem_Free(self.out)
 
 
 cdef extern from "double_metaphone.h":

--- a/src/fuzzy.pyx
+++ b/src/fuzzy.pyx
@@ -1,6 +1,7 @@
 # cython: c_string_type=unicode, c_string_encoding=ascii
 
 import re
+from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 
 
 cdef extern from "string.h":
@@ -203,7 +204,7 @@ cdef class Soundex:
 
         written = 0
 
-        out = <char *>malloc(self.size + 1)
+        out = <char *>PyMem_Malloc(self.size + 1)
         cs = s
         ls = strlen(cs)
         for i from 0<= i < ls:
@@ -227,7 +228,7 @@ cdef class Soundex:
         try:
             return out
         finally:
-            free(out)
+            PyMem_Free(out)
 
 
 cdef extern from "double_metaphone.h":

--- a/test/test_fuzzy.py
+++ b/test/test_fuzzy.py
@@ -80,3 +80,14 @@ def test_soundex_repeated_uses(texts, size):
         assert original_text == text
         assert cython_out == python_soundex(text)
 
+
+@given(st.lists(cython_input_strategy, min_size=100, max_size=200, unique=True), st.integers(1, 10))
+def test_doesnt_mutate_output_buffer(texts, size):
+    cython_soundex = fuzzy.Soundex(size)
+    python_soundex = PythonSoundex(size)
+
+    # maintain a list of all of cythons output values
+    cython_outputs = [cython_soundex(text) for text in texts]
+    python_outputs = [python_soundex(text) for text in texts]
+
+    assert cython_outputs == python_outputs

--- a/test/test_fuzzy.py
+++ b/test/test_fuzzy.py
@@ -2,36 +2,81 @@
 
 from __future__ import unicode_literals
 
-import pytest
 import ctypes
+import string
+
+import pytest
+from hypothesis import given, note
+from hypothesis import strategies as st
+from hypothesis import settings
 
 import fuzzy
 
 
-def test_soundex_does_not_mutate_strings():
-	phrase = 'FancyFree'
-	fuzzy.Soundex(4)(phrase)
-	buffer = ctypes.c_char_p(phrase.encode())
-	assert buffer.value.decode() == "FancyFree"
+class PythonSoundex(object):
+    # from sglib 5.0.0 https://github.com/seatgeek/sglib-py/commit/a8fddacb09c8a3edfada667f4244521d1dc68f69
+    def __init__(self, size):
+        self.size = size
+        self.map = "01230120022455012623010202"
+
+        self.memoized_outputs = {}
+
+    def __call__(self, s):
+        if s in self.memoized_outputs:
+            return self.memoized_outputs[s]
+
+        written = 0
+
+        ords = [ord(i) for i in s]
+        out = []
+        ls = len(s)
+        for i in range(0, ls):
+            c = ords[i]
+            if c >= 97 and c <= 122:
+                c = c - 32
+            if c >= 65 and c <= 90:
+                if written == 0:
+                    out.append(chr(c))
+                    written = written + 1
+                elif self.map[c - 65] != '0' and (written == 1 or
+                                                 out[written - 1] != self.map[c - 65]):
+                    out.append(self.map[c - 65])
+                    written = written + 1
+            if written == self.size:
+                break
+
+        for i in range(written, self.size):
+            out.append('0')
+
+        ret = ''.join(out)
+        self.memoized_outputs[s] = ret
+        return ret
 
 
-@pytest.mark.xfail(reason="issue #14")
-def test_soundex_result():
-	phrase = 'FancyFree'
-	res = fuzzy.Soundex(4)(phrase)
-	assert res == 'F521'
+cython_input_strategy = st.text(alphabet=string.ascii_letters + string.digits, min_size=1, max_size=30)
 
 
-@pytest.mark.xfail(reason="issue #14")
-def test_soundex_Test():
-	assert fuzzy.Soundex(8)('Test') == 'T23'
+@given(cython_input_strategy, st.integers(1, 10))
+def test_soundex(text, size):
+    # copy over original text to make sure soundex doesn't mutate text
+    original_text = text[:]
+
+    cython_out = fuzzy.Soundex(size)(text)
+
+    assert text == original_text
+    assert cython_out == PythonSoundex(size)(text)
 
 
-@pytest.mark.xfail(reason="issue #15")
-def test_soundex_non_ascii():
-	assert fuzzy.Soundex(8)('Jéroboam') == 'J615'
+@given(st.lists(cython_input_strategy, min_size=100, max_size=200, unique=True), st.integers(1, 10))
+def test_soundex_repeated_uses(texts, size):
+    cython_soundex = fuzzy.Soundex(size)
+    python_soundex = PythonSoundex(size)
 
+    for text in texts:
+        print(text)
+        original_text = text[:]
 
-def test_DMetaphone():
-	m = fuzzy.DMetaphone()
-	assert m("mayer") == [b'MR', None]
+        cython_out = cython_soundex(text)
+        assert original_text == text
+        assert cython_out == python_soundex(text)
+


### PR DESCRIPTION
### context

currently `fuzzy.Soundex` has occasional undefined behavior on py3, as discussed in issue 14 on https://github.com/yougov/fuzzy and can be reproduced by running this script locally:

```py
import itertools
import fuzzy

soundex = fuzzy.Soundex(6)

def main():
    # keep running the soundex function on the same input until encountering a UnicodeDecodeError
    for attempt in itertools.count():
        try:
            soundex('input')
        except UnicodeDecodeError as e:
            print(f'error on iteration {attempt}, err: {e}')
            break

if __name__ == "__main__":
    main()
```
```sh
# script output
(venv) Zach-Hammer:fuzzy zachhammer$ python3 soundextest.py 
error on iteration 2227560, err: 'ascii' codec can't decode byte 0xc1 in position 4
: ordinal not in range(128)
```

the `UnicodeDecodeError` is easiest to replicate as it breaks the code flow, but as noted in `#14` the function can return valid (but incorrect) python strings

### early deallocation of output string

i have a feeling this is occurring because of a change in python2/python3 cython behavior in this block:
https://github.com/zhammer/fuzzy-fork/blob/e15b195467223a684a26fadb53997bf6f36be2c4/src/fuzzy.pyx#L227-L230

1. we assign `pout = out`
    * `pout` has no declared type (from looking at compiled c code it seems to be a `char *`)
    * the [cython string docs](http://docs.cython.org/en/latest/src/tutorial/strings.html) aren't super clear here, but i'd imagine this is just a `char *` start pointer copy
2. we free `out`
    * those bytes can be overwritten at any time, possibly even on `free` iirc
3. we return `pout`
    * from the c compiled code, it seems like a few things happen here, most notably: `__pyx_t_5 = __Pyx_PyUnicode_FromString(__pyx_v_pout); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 230, __pyx_L1_error)` which seems to be doing some `char *` -> py string coercion
    * at some point here the free'd memory can be overwritten
    * that'd either lead to a `UnicodeDecodeError` if attempting to decode garbage bytes, or some random string output if the bytes are valid as a python string

i think we're only seeing this on py3 as the attempted decode of bytes to unicode raises a unicodedecodeerror. on py2 this'd just silently return a garbage string.

### fix

use proper memory allocation/deallocation for soundex function
also adds tests to verify behavior against an inpython implementation of soundex